### PR TITLE
103-deleting-lessons-doesnt-delete

### DIFF
--- a/src/store/attemptReducer.ts
+++ b/src/store/attemptReducer.ts
@@ -2,6 +2,7 @@ import { createSlice, createAsyncThunk } from "@reduxjs/toolkit";
 import { getQuizAttempts, createQuizAttempt, rateQuiz } from "../api/quiz/api";
 import { QuizAttempt, QuizAnswerSubmittion } from "../api/quiz/types";
 import { deleteQuizAsync } from "./quizReducer";
+import { deleteLessonAsync } from "./lessonReducer";
 
 export const fetchQuizAttempts = createAsyncThunk(
   "attempt/fetchQuizAttempts",
@@ -53,6 +54,12 @@ const attemptSlice = createSlice({
       })
       .addCase(deleteQuizAsync.fulfilled, (state, action) => {
         delete state.attemptsByQuiz[action.payload];
+      })
+      .addCase(deleteLessonAsync.fulfilled, (state, action) => {
+        const { quizIds } = action.payload;
+        for (const id of quizIds) {
+          delete state.attemptsByQuiz[id];
+        }
       });
   },
 });

--- a/src/store/lessonReducer.ts
+++ b/src/store/lessonReducer.ts
@@ -7,6 +7,7 @@ import {
   mergeLessons,
   generateLesson,
 } from "../api/lesson/api";
+import { RootState } from "./store";
 
 export const fetchLessons = createAsyncThunk(
   "lesson/fetchLessons",
@@ -18,8 +19,17 @@ export const fetchLessons = createAsyncThunk(
 
 export const createLessonAsync = createAsyncThunk(
   "lesson/createLesson",
-  async ({ videoUrl, relatedLessonGroupId }: { videoUrl: string; relatedLessonGroupId?: string }) => {
-    const response = await generateLesson(videoUrl, relatedLessonGroupId ?? null);
+  async ({
+    videoUrl,
+    relatedLessonGroupId,
+  }: {
+    videoUrl: string;
+    relatedLessonGroupId?: string;
+  }) => {
+    const response = await generateLesson(
+      videoUrl,
+      relatedLessonGroupId ?? null
+    );
     return response.data;
   }
 );
@@ -34,9 +44,13 @@ export const updateLessonAsync = createAsyncThunk(
 
 export const deleteLessonAsync = createAsyncThunk(
   "lesson/deleteLesson",
-  async (lessonId: string) => {
+  async (lessonId: string, {getState}) => {
     await deleteLesson(lessonId);
-    return lessonId;
+    const state = getState() as RootState;
+    const quizIds = Object.values(state.quizzes.quizzes)
+      .filter((quiz) => quiz.lessonId === lessonId)
+      .map((quiz) => quiz._id);
+    return {lessonId, quizIds};
   }
 );
 
@@ -72,7 +86,7 @@ const lessonSlice = createSlice({
       })
       .addCase(deleteLessonAsync.fulfilled, (state, action) => {
         state.lessons = state.lessons.filter(
-          (lesson) => lesson._id !== action.payload
+          (lesson) => lesson._id !== action.payload.lessonId
         );
       })
       .addCase(mergeLessonsAsync.fulfilled, (state, action) => {

--- a/src/store/quizReducer.ts
+++ b/src/store/quizReducer.ts
@@ -6,8 +6,8 @@ import {
   updateQuiz,
 } from "../api/quiz/api";
 import { QuizData, QuizSettings } from "../api/quiz/types";
+import { deleteLessonAsync } from "./lessonReducer";
 
-// Async thunks
 export const fetchQuizzes = createAsyncThunk(
   "quiz/fetchQuizzes",
   async (lessonId: string) => {
@@ -80,6 +80,11 @@ const quizSlice = createSlice({
       .addCase(updateQuizAsync.fulfilled, (state, action) => {
         state.quizzes = state.quizzes.map((quiz) =>
           quiz._id === action.payload._id ? action.payload : quiz
+        );
+      })
+      .addCase(deleteLessonAsync.fulfilled, (state, action) => {
+        state.quizzes = state.quizzes.filter(
+          (quiz) => quiz.lessonId !== action.payload.lessonId
         );
       });
   },


### PR DESCRIPTION
When deleting a lesson, all its quizzes and all their attempts are also deleted.

In deleteLesson action (upper part of reducer), returning the lesson's quizzes from the state, so in the attempt reducer I can use them to delete all the quizzes' attempts of that lesson.