### PR TITLE
fix-summary-size-in-shrinking

### DIFF
--- a/src/pages/lesson/LessonInfo/LessonInfo.styles.ts
+++ b/src/pages/lesson/LessonInfo/LessonInfo.styles.ts
@@ -10,7 +10,7 @@ const useStyles = makeStyles(() =>
     },
     leftBox: {
       flex: 6,
-      minWidth: 0, // allows box to shrink if needed, to let overflow work
+      minWidth: "50%", // allows box to shrink if needed, to let overflow work
     },
     rightBox: {
       flex: 4,


### PR DESCRIPTION
Fixes a bug that when hiding the summary, the size shrinks.
Makes it by setting the minimum width to what it is now when open.

![‏‏צילום מסך (34)](https://github.com/user-attachments/assets/7ebabda2-92d8-4b22-8c36-0f6ed990ae27)
