### PR TITLE
72-changing-or-keeping-same-quiz-settings

### DIFF
--- a/src/pages/lesson/LessonInfo/LessonInfo.styles.ts
+++ b/src/pages/lesson/LessonInfo/LessonInfo.styles.ts
@@ -6,6 +6,7 @@ const useStyles = makeStyles(() =>
       display: "flex",
       gap: "2vw",
       maxWidth: "100%",
+      minWidth: 0, // allows box to shrink properly, otherwise there's an overflow
       overflowY: "hidden",
     },
     leftBox: {

--- a/src/pages/lesson/LessonInfo/LessonInfo.styles.ts
+++ b/src/pages/lesson/LessonInfo/LessonInfo.styles.ts
@@ -15,6 +15,7 @@ const useStyles = makeStyles(() =>
     rightBox: {
       flex: 4,
       minWidth: 0, // allows box to shrink if needed, to let overflow work
+      overflowY: "auto",
     },
     title: {
       "&.MuiTypography-root": {

--- a/src/pages/lesson/LessonInfo/LessonInfo.tsx
+++ b/src/pages/lesson/LessonInfo/LessonInfo.tsx
@@ -11,10 +11,9 @@ import Box from "@mui/material/Box";
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { LessonData } from "../../../api/lesson/types";
-import { QuizData, QuizSettings } from "../../../api/quiz/types";
+import { QuizData } from "../../../api/quiz/types";
 import QuizItem from "../QuizItem/QuizItem";
 import useStyles from "./LessonInfo.styles";
-import { INITIAL_QUIZ_SETTINGS } from "../../../api/quiz/constants";
 import {
   deleteQuizAsync,
   fetchQuizzes,
@@ -32,14 +31,12 @@ interface LessonInfoProps {
 const LessonInfo: React.FC<LessonInfoProps> = ({ lesson, onClose }) => {
   const classes = useStyles();
   const quizzes = useSelector((state: RootState) => state.quizzes.quizzes);
-  const [isSummaryExpanded, setIsSummaryExpanded] = useState(true); // Default to true (show summary)
+  const [isSummaryExpanded, setIsSummaryExpanded] = useState(true);
   const dispatch = useDispatch<AppDispatch>();
-
   const navigate = useNavigate();
-  const quizSettings: QuizSettings = INITIAL_QUIZ_SETTINGS;
 
   const onCreateQuiz = () => {
-    navigate("/quiz", { state: { lessonData: lesson, quizSettings } });
+    navigate("/quiz", { state: { lessonData: lesson } });
   };
 
   useEffect(() => {

--- a/src/pages/lesson/LessonItem/LessonItem.styles.ts
+++ b/src/pages/lesson/LessonItem/LessonItem.styles.ts
@@ -31,6 +31,7 @@ const useStyles = makeStyles((theme: Theme) => {
       paddingLeft: "0.5vw",
     },
     editableActionsColumn: {
+      marginLeft: "0.5vw",
       display: "flex",
       flexDirection: "column",
       width: "82%",

--- a/src/pages/quiz/Quiz.tsx
+++ b/src/pages/quiz/Quiz.tsx
@@ -26,7 +26,7 @@ const QUIZ_CONTENT_PDF_ID = "quiz-content";
 
 type LocationProps =
   | {
-      quizSettings: QuizSettings;
+      quizSettings?: QuizSettings;
       quizId?: undefined;
       viewAttempt?: undefined;
       attemptToContinue?: undefined;
@@ -107,7 +107,9 @@ const QuizPage: React.FC = () => {
 
   const dispatch = useDispatch<AppDispatch>();
 
-  const [showQuizSettings, setShowQuizSettings] = useState(false);
+  const [showQuizSettings, setShowQuizSettings] = useState(
+    !locationState.quizId && !locationState.quizSettings
+  );
 
   const loggedUser = useSelector((state: RootState) => state.user.loggedUser);
 
@@ -133,7 +135,7 @@ const QuizPage: React.FC = () => {
       const data = await dispatch(
         generateQuizAsync({
           lessonId: locationState.lessonData._id,
-          settings: locationState.quizSettings ?? quizData?.settings,
+          settings: quizSettings,
         })
       ).unwrap();
       setQuizId(data._id);
@@ -156,7 +158,7 @@ const QuizPage: React.FC = () => {
   }, [currentAttempt]);
 
   useEffect(() => {
-    if (!quizId) {
+    if (!showQuizSettings) {
       generateNewQuiz();
     }
   }, []);

--- a/src/pages/summary/Summary.tsx
+++ b/src/pages/summary/Summary.tsx
@@ -1,10 +1,10 @@
 import { CardContent, Typography } from "@mui/material";
 import useStyles from "./Summary.styles";
 
-type Summary2Props = {
+type SummaryProps = {
   summary: string;
 };
-export function Summary(props: Summary2Props) {
+export function Summary(props: SummaryProps) {
   const classes = useStyles();
   return (
     <CardContent>


### PR DESCRIPTION
Fixed the bug that retaking a quiz didn't keep its settings. The problem was it used the initial values of quizSettings, but not quizSettings itself. So later when we update quizSettings, it didn't keep up with the updates, so it always saved a quiz with "onSubmit" mode.

Made quizSettings optional in Quiz, so not sending it for "create new quiz", and showquizsettings is the condition of whether to generate a new quiz.

Bring back overflowY to LessonInfo, because too many attempts were cut. The overflow is for the attempts only, and not for the entire page.