### PR TITLE
fiz-quiz-show-settings

### DIFF
--- a/src/pages/lesson/LessonOverview/LessonOverviewPage.tsx
+++ b/src/pages/lesson/LessonOverview/LessonOverviewPage.tsx
@@ -13,7 +13,6 @@ import { RelatedVideo } from "../../../api/lesson/types";
 import LessonOverviewSkeleton from "./LessonOverviewSkeleton.tsx";
 import { Summary } from "../../summary/Summary.tsx";
 import { PAGES_ROUTES } from "../../../routes/routes.const.ts";
-import { generateQuizAsync } from "../../../store/quizReducer.ts";
 
 const LessonOverviewPage: React.FC = () => {
   const location = useLocation();
@@ -36,18 +35,10 @@ const LessonOverviewPage: React.FC = () => {
     }
 
     try {
-      const data = await dispatch(
-        generateQuizAsync({
-          lessonId: lessonData._id,
-          settings: quizSettings,
-        })
-      ).unwrap();
-
       navigate(PAGES_ROUTES.QUIZ, {
         state: {
           lessonData,
-          quizId: data._id,
-          quizSettings: quizSettings,
+          quizSettings,
         },
       });
     } catch (error) {

--- a/src/pages/quiz/Quiz.tsx
+++ b/src/pages/quiz/Quiz.tsx
@@ -108,8 +108,14 @@ const QuizPage: React.FC = () => {
   const dispatch = useDispatch<AppDispatch>();
 
   const [showQuizSettings, setShowQuizSettings] = useState(
-    !locationState.quizId && !locationState.quizSettings
+    !locationState.quizId &&
+      !locationState.quizSettings &&
+      !locationState.attemptToContinue &&
+      !locationState.viewAttempt
   );
+  const isGenerateNewQuiz =
+    locationState.quizId !== undefined ||
+    locationState.quizSettings !== undefined;
 
   const loggedUser = useSelector((state: RootState) => state.user.loggedUser);
 
@@ -158,7 +164,7 @@ const QuizPage: React.FC = () => {
   }, [currentAttempt]);
 
   useEffect(() => {
-    if (!showQuizSettings) {
+    if (isGenerateNewQuiz) {
       generateNewQuiz();
     }
   }, []);


### PR DESCRIPTION
fix when to show quiz settings component, and when to generate a new quiz.

Not generating the quiz in LessonOverviewPage anymore, instead generating it in the Quiz component, to have the skeleton loading.