### PR TITLE
82-refreshing-attempt--answers-disappear

### DIFF
--- a/src/store/selectors/attemptSelector.tsx
+++ b/src/store/selectors/attemptSelector.tsx
@@ -5,8 +5,8 @@ export const selectAttemptSelector = (
   quizId?: string,
   attemptId?: string
 ) => {
-  if (!quizId || !attemptId) return undefined;
+  if (!quizId || !attemptId) return null;
   const attempts = state.attempt.attemptsByQuiz[quizId];
-  if (!attempts) return undefined;
-  return attempts.find((attempt) => attempt._id === attemptId);
+  if (!attempts) return null;
+  return attempts.find((attempt) => attempt._id === attemptId) ?? null;
 };


### PR DESCRIPTION
Fixed bugs of refreshing the Quiz page. The problem was the quiz attempts never re-loaded, so currentAttempt was always undefined in refresh (it wasn't before refresh because we came from LessonsPage, which fetched the quiz's attempts).

To fix it, I fetch the quiz attempts every refresh, and I only try to get currentAttempt after the quiz attempts fully loaded.