### PR TITLE
fix-build-type-mistake

### DIFF
--- a/src/pages/quiz/Quiz.tsx
+++ b/src/pages/quiz/Quiz.tsx
@@ -361,7 +361,7 @@ const QuizPage: React.FC = () => {
                     isLocked={isLocked}
                     setIsLocked={setIsLocked}
                     isOnSelectAnswerMode={isOnSelectAnswerMode}
-                    currentAttempt={currentAttempt}
+                    currentAttempt={currentAttempt ?? undefined}
                     handleOptionChange={handleOptionChange}
                   />
                 </Box>


### PR DESCRIPTION
Fix so it's passing attempt | undefined to the component, so it doesn't throw build errors.