### PR TITLE
92-retake-quiz-bug

### DIFF
--- a/src/pages/quiz/Quiz.tsx
+++ b/src/pages/quiz/Quiz.tsx
@@ -149,7 +149,8 @@ const QuizPage: React.FC = () => {
       !locationState.viewAttempt
   );
   const isGenerateNewQuiz =
-    locationState.quizId !== undefined ||
+    locationState.lessonData !== undefined &&
+    locationState.quizId === undefined &&
     locationState.quizSettings !== undefined;
 
   const loggedUser = useSelector((state: RootState) => state.user.loggedUser);


### PR DESCRIPTION
Fix condition of when to generate a new quiz- only when you create a new lesson and from it doing "go to quiz"