### PR TITLE
95 bug refresh on lesson

### DIFF
--- a/src/pages/generateLesson/GenerateLessonPage.tsx
+++ b/src/pages/generateLesson/GenerateLessonPage.tsx
@@ -8,6 +8,7 @@ import LessonConfig from "../../components/lessonConfig/LessonConfig";
 import { PAGES_ROUTES } from "../../routes/routes.const";
 import { RootState } from "../../store/store";
 import useStyles from "../../components/lessonConfig/components/styles";
+import { LESSON_CREATED_FLAG } from "../lesson/LessonOverview/LessonOverviewPage";
 
 const GenerateLessonPage: React.FC = () => {
   const navigate = useNavigate();
@@ -24,6 +25,7 @@ const GenerateLessonPage: React.FC = () => {
     useState<QuizSettings>(defaultQuizSettings);
 
   const handleSummaryNavigation = (): void => {
+    localStorage.removeItem(LESSON_CREATED_FLAG);
     navigate(PAGES_ROUTES.SUMMARY, {
       state: { videoUrl, quizSettings, relatedLessonGroupId },
     });


### PR DESCRIPTION
If doing a refresh in the summary page after creating a lesson (summary + related videos), don't create a new lesson, instead fetch the existing lesson.

If relatedVideos fails, still allow to see the lesson summary and go to quiz.